### PR TITLE
ci: modernize release workflow for current runners and actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,26 +16,24 @@ jobs:
             target: x86_64-pc-windows-msvc
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - os: macos-12
+          - os: macos-13
             target: x86_64-apple-darwin
-          - os: macos-12
+          - os: macos-14
             target: aarch64-apple-darwin
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Setup Rust Toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
-
-      - name: Install target
-        run: rustup target add ${{ matrix.target }}
-        if: contains(fromJSON('["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]'), matrix.target)
+        with:
+          target: ${{ matrix.target }}
 
       - name: Install libxdo-dev
         if: matrix.target == 'x86_64-unknown-linux-gnu'
-        run: sudo apt-get update && sudo apt-get install libxdo-dev
+        run: sudo apt-get update && sudo apt-get install -y libxdo-dev
 
       - name: Build
         run: cargo build --verbose --locked -F bin --release --target ${{ matrix.target }}
@@ -51,13 +49,13 @@ jobs:
           tar zcf $staging.tar.gz $staging
           echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: release
+          name: release-${{ matrix.target }}
           path: ${{ env.ASSET }}
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           draft: true
@@ -68,12 +66,15 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') # Only runs this job if the push is a tag
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           profile: minimal # Only install what's necessary
+
+      - name: Install libxdo-dev
+        run: sudo apt-get update && sudo apt-get install -y libxdo-dev
 
       - name: Publish to crates.io
         env:


### PR DESCRIPTION
Fixes the bit-rotted `release.yml` so a future `v*` tag actually produces binaries and publishes to crates.io. No tag is being cut here — this just gets the pipeline ready.

## Changes
- **Runners:** retired `macos-12` → native `macos-13` (x86_64) + `macos-14` (aarch64). The macos-12 image no longer exists, so the macOS build jobs couldn't start.
- **Actions:** `actions/checkout` v3 → v5, `actions/upload-artifact` v3 → v4 (v3 is disabled by GitHub), `softprops/action-gh-release` v1 → v2.
- **upload-artifact v4 fix:** each matrix job now uploads a uniquely named artifact (`release-<target>`); v4 rejects multiple jobs writing the same artifact name.
- **Toolchain:** install the build target via `setup-rust-toolchain`'s `target:` input instead of a separate `rustup target add` step (targets are now native to each runner anyway).
- **Publish job:** install `libxdo-dev` before `cargo publish` so the crates.io verification build can link `enigo` on Linux.

## Notes
Release flow is unchanged: pushing a `v0.2.0` tag builds all four targets, creates a **draft** GitHub release, and publishes `keep-active` to crates.io. Cutting that tag is intentionally left for a follow-up.
